### PR TITLE
Add a link to the indexes

### DIFF
--- a/en/endpoints.measurements.md
+++ b/en/endpoints.measurements.md
@@ -23,7 +23,7 @@ The field `current` contains averaged measurements for the **last 60 minutes** (
 - **indexes** - array of objects of type _Index_; single element represents an index value calculated for the measurements in this payload
     - **name**  (_string_) - name of the index (e.g. CAQI, or PIJP)
     - **value** (_double_) - numerical value of the calculated index
-    - **level** (_string_) - discreet level of the index (e.g. HIGH, or LOW etc.)
+    - **level** (_string_) - [discreet level of the index](#endpoints.meta.indexes) (e.g. HIGH, or LOW etc.)
     - **description** (_string_) - description of the index level; the text translated and returned in a language according to `Accept-Language` request header
     - **advice** (_string_) - additional text with advice regarding current index level; the text translated and returned in a language according to `Accept-Language` request header
     - **color** (_string_) - color representing index level; in a form of hexadecimal RGB triplet (e.g. #D1CF1E)

--- a/pl/endpoints.measurements.md
+++ b/pl/endpoints.measurements.md
@@ -23,7 +23,7 @@ Obiekt **AveragedValues** składa się z pól:
 - **indexes** - lista obiektów typu _Index_; pojedynczy obiekt reprezentuje wartość indeksu obliczonego dla danych pomiarowych zawartych w values
     - **name**  (_string_) - nazwa obliczonego indeksu (np. CAQI, albo PIJP)
     - **value** (_double_) -  wartość numeryczna obliczonego indeksu
-    - **level** (_string_) -  poziom indeksu (np. HIGH, albo LOW itp)
+    - **level** (_string_) -  [poziom indeksu](#endpoints.meta.indexes) (np. HIGH, albo LOW itp)
     - **description** (_string_) -  tekstowy opis danego poziomu zanieczyszczeń; wartość pola jest zwracana w języku wedle nagłówka `Accept-Language`
     - **advice** (_string_) -  dodatkowy tekst zawierający zalecenia dot. danego poziomu zanieczyszczeń; wartość pola jest zwracana w języku wedle nagłówka `Accept-Language`
     - **color** (_string_) -  kolor odpowiadający danemu poziomowi indeksu; w formacie heksadecymalnym RGB (np. #D1CF1E)


### PR DESCRIPTION
When creating something with the API I struggled to find all indexes available. I think giving a link to the meta endpoint should solve the problem.